### PR TITLE
Shrink binary size by omitting symbol tables and disabling CGO

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ mklink /D "%GOPATH%\src\github.com\jesseduffield\lazygit" "%SRC_DIR%" || goto :e
 cd "%GOPATH%\src\github.com\jesseduffield\lazygit"
 
 :: build the project
+set "CGO_ENABLED=0"  :: disable CGO, as there are no C libs to load
 go get -v || goto :error
 go build || goto :error
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,8 +10,10 @@ cd "%GOPATH%\src\github.com\jesseduffield\lazygit"
 
 :: build the project
 set "CGO_ENABLED=0"  :: disable CGO, as there are no C libs to load
-go get -v || goto :error
-go build || goto :error
+set "LDFLAGS=-s -w"  :: omit the symbol table / debug information and
+                     :: DWARF symbol table.
+go get -v -ldflags "%LDFLAGS%" || goto :error
+go build  -ldflags "%LDFLAGS%" || goto :error
 
 :: install the binary
 mv "%GOPATH%\bin\lazygit" "%LIBRARY_BIN%\lazygit" || goto :error

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,18 @@
-rem go one level up
+:: go one level up
 cd %SRC_DIR%
 cd ..
 
-rem create the gopath directory structure
+:: create the gopath directory structure
 set "GOPATH=%CD%\gopath"
 mkdir "%GOPATH%\src\github.com\jesseduffield" || goto :error
 mklink /D "%GOPATH%\src\github.com\jesseduffield\lazygit" "%SRC_DIR%" || goto :error
 cd "%GOPATH%\src\github.com\jesseduffield\lazygit"
 
-rem build the project
+:: build the project
 go get -v || goto :error
 go build || goto :error
 
-rem install the binary
+:: install the binary
 mv "%GOPATH%\bin\lazygit" "%LIBRARY_BIN%\lazygit" || goto :error
 goto :EOF
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,7 @@ ln -s "$SRC_DIR" "$GOPATH/src/github.com/jesseduffield/lazygit"
 cd "$GOPATH/src/github.com/jesseduffield/lazygit"
 
 # build the project
+export CGO_ENABLED=0  # disable CGO, as there are no C libs to load
 go get -v
 go build
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,8 +14,10 @@ cd "$GOPATH/src/github.com/jesseduffield/lazygit"
 
 # build the project
 export CGO_ENABLED=0  # disable CGO, as there are no C libs to load
-go get -v
-go build
+LDFLAGS="-s -w"       # omit the symbol table / debug information and
+                      # DWARF symbol table.
+go get -v -ldflags "${LDFLAGS}"
+go build  -ldflags "${LDFLAGS}"
 
 # install the binary
 mkdir -p "$PREFIX/bin"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False
   detect_binary_files_with_prefix: False
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
